### PR TITLE
Fix missing tab message

### DIFF
--- a/tools.php
+++ b/tools.php
@@ -125,7 +125,7 @@ add_action('wgpt_render_tab_tools', function () {
     if (file_exists($tab_file)) {
         include $tab_file;
     } else {
-        echo '<div class="notice notice-error"><p>тЪая╕П tools.php: Tab UI file not found at <code>' . esc_html($tab_file) . '</code></p></div>';
+        echo '<div class="notice notice-error"><p>Error in tools.php: Tab UI file not found at <code>' . esc_html($tab_file) . '</code></p></div>';
     }
 });
 


### PR DESCRIPTION
## Summary
- display a clean notice instead of garbled characters when the tools tab file is missing

## Testing
- `php -l tools.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586d9a48488329bc84f44f185cc39c