### PR TITLE
Sanitize wgpt_role parameter

### DIFF
--- a/tabs/tab-access.php
+++ b/tabs/tab-access.php
@@ -46,7 +46,7 @@ if (!function_exists('gpt_get_capability_map')) {
 
 $roles = wp_roles()->roles;
 $map   = gpt_get_capability_map();
-$selected_role = $_GET['wgpt_role'] ?? '';
+$selected_role = isset($_GET['wgpt_role']) ? sanitize_key($_GET['wgpt_role']) : '';
 
 ?>
 <div class="wrap">


### PR DESCRIPTION
## Summary
- sanitize `wgpt_role` GET parameter

## Testing
- `php -l tabs/tab-access.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586d912bd8832988b56f5ee9e80e18